### PR TITLE
Add docker-compose setup

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,10 @@
+version: '3'
+services:
+  prosper-1099-parser:
+    image: openjdk:17-jdk-bullseye
+    volumes:
+      - './:/opt/prosper-1099-parser'
+    working_dir: /opt/prosper-1099-parser
+    ports:
+      - '8080:8080'
+    command: ./gradlew clientInstall bootRun


### PR DESCRIPTION
For people with docker setup, this patch makes running the project as easy as:
```
docker compose up
```
(or `docker-compose up` for people with older docker clients)